### PR TITLE
Add sleep/serialize recursion.

### DIFF
--- a/class-sleep-recursion.php
+++ b/class-sleep-recursion.php
@@ -1,0 +1,17 @@
+<?php
+/* Recursion in __sleep() function.
+ *
+ * Crashes all currently supported PHP versions (5.6, 7.0, 7.1).
+ *
+ * A __sleep() function that calls serialize() on the (serialized) object itself, causing a recursion.
+ */
+
+class s
+{
+    public function __sleep()
+    {
+        serialize($this);
+    }
+}
+
+serialize(new s());


### PR DESCRIPTION
Similar to the `clone` recursion, you can trigger a segfault due to an endless `serialize()` recursion.